### PR TITLE
Build springboot from HEAD

### DIFF
--- a/springboot.rb
+++ b/springboot.rb
@@ -5,11 +5,23 @@ class Springboot < Formula
 	url 'https://repo.spring.io/milestone/org/springframework/boot/spring-boot-cli/0.5.0.M7/spring-boot-cli-0.5.0.M7-bin.tar.gz'
 	version '0.5.0.M7'
 	sha1 'c4a0ae98da62fbaaf96e3004e6982b74247b3ca0'
+	head 'https://github.com/spring-projects/spring-boot.git'
+
+	if build.head?
+		depends_on 'maven' => :build
+	end
 
 	def install
-		bin.install 'bin/spring'
-		lib.install 'lib/spring-boot-cli-0.5.0.M7.jar'
-		bash_completion.install 'shell-completion/bash/spring'
-		zsh_completion.install 'shell-completion/zsh/_spring'
+		if build.head?
+			Dir.chdir('spring-boot-cli') { system 'mvn -U -DskipTests=true package' }
+			root = 'spring-boot-cli/target/spring-boot-cli-*-bin/spring-*'
+		else
+			root = '.'
+		end
+
+		bin.install Dir["#{root}/bin/spring"]
+		lib.install Dir["#{root}/lib/spring-boot-cli-*.jar"]
+		bash_completion.install Dir["#{root}/shell-completion/bash/spring"]
+		zsh_completion.install Dir["#{root}/shell-completion/zsh/_spring"]
 	end
 end


### PR DESCRIPTION
Previously, the `spring boot` formula would only download and install the latest milestone.  For people testing snapshots (and not wanting to do a manual installation), this wasn't entirely helpful.  This change adds support for Homebrew's [unstable version support]().  Users can now do a

``` bash
brew install springboot --HEAD
```

and get an install built from the `HEAD` of the Spring Boot repo.
