### PR TITLE
springxd formula needs to install gemfire binaries

### DIFF
--- a/springxd.rb
+++ b/springxd.rb
@@ -17,6 +17,7 @@ class Springxd < Formula
     libexec.install Dir['*']
     bin.install_symlink Dir["#{libexec}/shell/bin/*"]
     bin.install_symlink Dir["#{libexec}/xd/bin/*"]
+    bin.install_symlink Dir["#{libexec}/gemfire/bin/*"]
   end
 
   def caveats; <<-EOS.undent


### PR DESCRIPTION
springxd comes with a simplified gemfire binary. Need to install that as well into /usr/local/bin.
