### PR TITLE
cloudfoundry-cli: mark x86_64 dependency

### DIFF
--- a/cloudfoundry-cli.rb
+++ b/cloudfoundry-cli.rb
@@ -7,6 +7,8 @@ class CloudfoundryCli < Formula
   version '6.1.2'
   sha1 '19df87677b92129f01e339e1f8f043831b6168d3'
 
+  depends_on :arch => :x86_64
+
   def install
     bin.install 'cf'
   end


### PR DESCRIPTION
Since the cloudfactory-cli formula uses an x86_64-only binary, the formula won't work on 32-bit Intel hosts. This marks that dep so that users on 32-bit only systems will get an informative message when trying to install.
