### PR TITLE
Updating to 6.2.0.

### DIFF
--- a/cloudfoundry-cli.rb
+++ b/cloudfoundry-cli.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CloudfoundryCli < Formula
   homepage 'https://github.com/cloudfoundry/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.1.2'
-  version '6.1.2'
-  sha1 '19df87677b92129f01e339e1f8f043831b6168d3'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.2.0&source=homebrew'
+  version '6.2.0'
+  sha1 '0e1dea612419ca9e9d6aae985c7c84cc6bb62a38'
 
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
CF has been updated to 6.2.0 from 6.1.2. Update formula to point to new version.
