### PR TITLE
Bump version to 6.6.1

### DIFF
--- a/cloudfoundry-cli.rb
+++ b/cloudfoundry-cli.rb
@@ -3,9 +3,9 @@ require 'formula'
 class CloudfoundryCli < Formula
   homepage 'https://github.com/cloudfoundry/cli'
   head 'https://cli.run.pivotal.io/edge?arch=macosx64&source=homebrew'
-  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.6.0&source=homebrew'
-  version '6.6.0'
-  sha1 '34d96ca67ed8d4bcf55f0ce88d5225aad3a393c1'
+  url 'https://cli.run.pivotal.io/stable?release=macosx64-binary&version=6.6.1&source=homebrew'
+  version '6.6.1'
+  sha1 '7badf08418458a99c712b6431ba065cd39846032'
 
   depends_on :arch => :x86_64
 


### PR DESCRIPTION
Upgrade to 6.6.1 which contains many helpful bugfixes and reliability improvements.

For further details, see https://github.com/cloudfoundry/cli/releases/tag/v6.6.1
