### PR TITLE
bump git-together to 0.1.0-alpha.21

### DIFF
--- a/git-together.rb
+++ b/git-together.rb
@@ -1,11 +1,11 @@
 class GitTogether < Formula
-  VERSION = "0.1.0-alpha.17"
+  VERSION = "0.1.0-alpha.21"
 
   desc "Better commit attribution while pairing."
   homepage "https://github.com/kejadlen/git-together"
   version VERSION
   url "https://github.com/kejadlen/git-together/releases/download/v#{VERSION}/git-together-v#{VERSION}-x86_64-apple-darwin.tar.gz"
-  sha256 "663317392f662712c1a7a2299fc60d2fdae2c6a81f9ead5f490b574c69d27346"
+  sha256 "aeef14c94011af5c4acf7b07ef368fce098a15059d85a4a8f46a7f3525909973"
 
   depends_on "libssh2"
   depends_on "openssl@1.1"


### PR DESCRIPTION
- fixes the exit status code
- better `--global` support