### PR TITLE
java warnings sorted

### DIFF
--- a/gemfire@9.5.rb
+++ b/gemfire@9.5.rb
@@ -8,7 +8,7 @@ class GemfireAT95 < Formula
   
   bottle :unneeded
 
-  depends_on :java => "1.8"
+  depends_on ":openjdk@8"
 
   def install
     rm_f "bin/gfsh.bat"

--- a/trilogy.rb
+++ b/trilogy.rb
@@ -6,7 +6,7 @@ class Trilogy < Formula
   url "https://github.com/pivotal/trilogy/releases/download/v#{version}/trilogy-#{version}-mac-linux.tgz"
   sha256 "1c6f7039da26f0f909cf4daf7b73c9a91f2241c4108a1cdeb072fb5b3732378e"
 
-  depends_on :java
+  depends_on :openjdk
 
   def install
     bin.install "trilogy"


### PR DESCRIPTION
depends_on 'java' deprecated in favour of depends_on 'openjdk'