### PR TITLE
Depend on openjdk instead of java

### DIFF
--- a/trilogy.rb
+++ b/trilogy.rb
@@ -6,7 +6,7 @@ class Trilogy < Formula
   url "https://github.com/pivotal/trilogy/releases/download/v#{version}/trilogy-#{version}-mac-linux.tgz"
   sha256 "1c6f7039da26f0f909cf4daf7b73c9a91f2241c4108a1cdeb072fb5b3732378e"
 
-  depends_on :java
+  depends_on "openjdk"
 
   def install
     bin.install "trilogy"


### PR DESCRIPTION
Eliminates error while tapping
Error: Invalid formula: /usr/local/Homebrew/Library/Taps/pivotal/homebrew-tap/trilogy.rb
trilogy: Calling depends_on :java is disabled! Use "depends_on "openjdk@11", "depends_on "openjdk@8" or "depends_on "openjdk" instead.
Please report this issue to the pivotal/tap tap (not Homebrew/brew or Homebrew/core), or even better, submit a PR to fix it:
  /usr/local/Homebrew/Library/Taps/pivotal/homebrew-tap/trilogy.rb:9