### PR TITLE
[pivnet-cli] Add support for Silicon M1

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,0 +1,20 @@
+---
+on:
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  install:
+    runs-on: 	macos-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        formulae:
+          [
+            pivnet-cli,
+          ]
+    steps:
+      - uses: actions/checkout@v3
+      - run: brew tap pivotal-legacy/tap "file://${PWD}"
+      - run: brew install ${{ matrix.formulae }}
+

--- a/pivnet-cli.rb
+++ b/pivnet-cli.rb
@@ -6,8 +6,6 @@ class PivnetCli < Formula
   url "https://github.com/pivotal-cf/pivnet-cli/releases/download/v#{version}/pivnet-darwin-amd64-#{version}"
   sha256 "6eaadefe76eb96342b0ee8909625027b157e06d417e9a5ed8b413435c876351f"
 
-  depends_on :arch => :x86_64
-
   def install
     mv "pivnet-darwin-amd64-#{version}", "pivnet"
     bin.install "pivnet"


### PR DESCRIPTION
With this change, folks on MacOS powered by Apple Silicon M1 can also install `pivnet-cli` via Homebrew. Otherwise, Homebrew will complain about the CPU architecture.